### PR TITLE
support close typing

### DIFF
--- a/src/MarkdownCMD/index.tsx
+++ b/src/MarkdownCMD/index.tsx
@@ -8,171 +8,182 @@ import { useTypingTask } from '../hooks/useTypingTask.js';
 
 type MarkdownCMDProps = MarkdownProps;
 
-const MarkdownCMD = forwardRef<MarkdownCMDRef, MarkdownCMDProps>(({ interval = 30, onEnd, onStart, onTypedChar, timerType = 'setTimeout', theme = 'light', math, plugins }, ref) => {
-  /** 当前需要打字的内容 */
-  const charsRef = useRef<IChar[]>([]);
+const MarkdownCMD = forwardRef<MarkdownCMDRef, MarkdownCMDProps>(
+  ({ interval = 30, onEnd, onStart, onTypedChar, timerType = 'setTimeout', theme = 'light', math, plugins, isClosePrettyTyped = false }, ref) => {
+    /** 当前需要打字的内容 */
+    const charsRef = useRef<IChar[]>([]);
 
-  /**
-   * 打字是否已经完全结束
-   * 如果打字已经完全结束，则不会再触发打字效果
-   */
-  const isWholeTypedEndRef = useRef(false);
-  const charIndexRef = useRef(0);
-
-  /** 整个内容引用 */
-  const wholeContentRef = useRef<IWholeContent>({
-    thinking: {
-      content: '',
-      length: 0,
-    },
-    answer: {
-      content: '',
-      length: 0,
-    },
-    allLength: 0,
-  });
-
-  const [, setUpdate] = useState(false);
-  const triggerUpdate = () => {
-    setUpdate((prev) => !prev);
-  };
-
-  /**
-   * 处理字符显示逻辑
-   */
-  const processCharDisplay = (char: IChar) => {
-    if (char.answerType === 'thinking') {
-      wholeContentRef.current.thinking.content += char.content;
-      wholeContentRef.current.thinking.length += 1;
-    } else {
-      wholeContentRef.current.answer.content += char.content;
-      wholeContentRef.current.answer.length += 1;
-    }
-    triggerUpdate();
-  };
-
-  // 使用新的打字任务 hook
-  const typingTask = useTypingTask({
-    timerType,
-    interval,
-    charsRef,
-    onEnd,
-    onStart,
-    onTypedChar,
-    processCharDisplay,
-    wholeContentRef,
-  });
-
-  /**
-   * 内部推送处理逻辑
-   */
-  const processPushInternal = (content: string, answerType: AnswerType) => {
-    if (content.length === 0) {
-      return;
-    }
-
-    charsRef.current.push(
-      ...content.split('').map((chatStr) => {
-        const index = charIndexRef.current++;
-        const charObj: IChar = {
-          content: chatStr,
-          answerType,
-          contentType: 'segment',
-          tokenId: 0,
-          index,
-        };
-        return charObj;
-      }),
-    );
-
-    wholeContentRef.current.allLength += content.length;
-
-    if (!typingTask.isTyping()) {
-      typingTask.start();
-    }
-  };
-
-  useImperativeHandle(ref, () => ({
     /**
-     * 添加内容
-     * @param content 内容 {string}
-     * @param answerType 回答类型 {AnswerType}
+     * 打字是否已经完全结束
+     * 如果打字已经完全结束，则不会再触发打字效果
      */
-    push: (content: string, answerType: AnswerType) => {
-      processPushInternal(content, answerType);
-    },
+    const isWholeTypedEndRef = useRef(false);
+    const charIndexRef = useRef(0);
+
+    /** 整个内容引用 */
+    const wholeContentRef = useRef<IWholeContent>({
+      thinking: {
+        content: '',
+        length: 0,
+      },
+      answer: {
+        content: '',
+        length: 0,
+      },
+      allLength: 0,
+    });
+
+    const [, setUpdate] = useState(0);
+    const triggerUpdate = () => {
+      setUpdate((prev) => prev + 1);
+    };
+
     /**
-     * 清除打字任务
+     * 处理字符显示逻辑
      */
-    clear: () => {
-      typingTask.stop();
-      typingTask.typedIsManualStopRef.current = false;
-      charsRef.current = [];
-      wholeContentRef.current = {
-        thinking: {
-          content: '',
-          length: 0,
-        },
-        answer: {
-          content: '',
-          length: 0,
-        },
-        allLength: 0,
-      };
-      isWholeTypedEndRef.current = false;
-      charIndexRef.current = 0;
-      triggerUpdate();
-    },
-    /** 停止打字任务 */
-    stop: () => {
-      typingTask.stop();
-    },
-    /** 重新开始打字任务 */
-    resume: () => {
-      typingTask.resume();
-    },
-    /**
-     * 主动触发打字结束
-     */
-    triggerWholeEnd: () => {
-      isWholeTypedEndRef.current = true;
-      if (!typingTask.isTyping()) {
-        // 这里需要手动触发结束回调，因为 hook 中的 triggerOnEnd 不能直接调用
-        onEnd?.({
-          str: undefined,
-          answerType: undefined,
-        });
+    const processCharDisplay = (char: IChar) => {
+      if (char.answerType === 'thinking') {
+        wholeContentRef.current.thinking.content += char.content;
+        wholeContentRef.current.thinking.length += 1;
+      } else {
+        wholeContentRef.current.answer.content += char.content;
+        wholeContentRef.current.answer.length += 1;
       }
-    },
-    /**
-     * 刷新缓冲区 (新增方法)
-     */
-  }));
+      triggerUpdate();
+    };
 
-  const getParagraphs = (answerType: AnswerType) => {
+    // 使用新的打字任务 hook
+    const typingTask = useTypingTask({
+      timerType,
+      interval,
+      charsRef,
+      onEnd,
+      onStart,
+      onTypedChar,
+      processCharDisplay,
+      wholeContentRef,
+      isClosePrettyTyped,
+      triggerUpdate,
+    });
+
+    /**
+     * 内部推送处理逻辑
+     */
+    const processHasTypingPush = (content: string, answerType: AnswerType) => {
+      if (content.length === 0) {
+        return;
+      }
+
+      charsRef.current.push(
+        ...content.split('').map((chatStr) => {
+          const index = charIndexRef.current++;
+          const charObj: IChar = {
+            content: chatStr,
+            answerType,
+            contentType: 'segment',
+            tokenId: 0,
+            index,
+          };
+          return charObj;
+        }),
+      );
+
+      wholeContentRef.current.allLength += content.length;
+
+      if (!typingTask.isTyping()) {
+        typingTask.start();
+      }
+    };
+
+    const processNoTypingPush = (content: string, answerType: AnswerType) => {
+      wholeContentRef.current[answerType].content += content;
+      wholeContentRef.current[answerType].length += content.length;
+      triggerUpdate();
+    };
+
+    useImperativeHandle(ref, () => ({
+      /**
+       * 添加内容
+       * @param content 内容 {string}
+       * @param answerType 回答类型 {AnswerType}
+       */
+      push: (content: string, answerType: AnswerType) => {
+        if (isClosePrettyTyped) {
+          processNoTypingPush(content, answerType);
+          return;
+        }
+        processHasTypingPush(content, answerType);
+      },
+      /**
+       * 清除打字任务
+       */
+      clear: () => {
+        typingTask.stop();
+
+        typingTask.typedIsManualStopRef.current = false;
+        charsRef.current = [];
+        wholeContentRef.current.thinking.content = '';
+        wholeContentRef.current.thinking.length = 0;
+        wholeContentRef.current.answer.content = '';
+        wholeContentRef.current.answer.length = 0;
+        wholeContentRef.current.allLength = 0;
+        isWholeTypedEndRef.current = false;
+        charIndexRef.current = 0;
+
+        triggerUpdate();
+      },
+      /** 停止打字任务 */
+      stop: () => {
+        typingTask.stop();
+      },
+      /** 重新开始打字任务 */
+      resume: () => {
+        typingTask.resume();
+      },
+      /**
+       * 主动触发打字结束
+       */
+      triggerWholeEnd: () => {
+        isWholeTypedEndRef.current = true;
+        if (!typingTask.isTyping()) {
+          // 这里需要手动触发结束回调，因为 hook 中的 triggerOnEnd 不能直接调用
+          onEnd?.({
+            str: undefined,
+            answerType: undefined,
+          });
+        }
+      },
+      /**
+       * 刷新缓冲区 (新增方法)
+       */
+    }));
+
+    const getParagraphs = (answerType: AnswerType) => {
+      const content = wholeContentRef.current[answerType].content || '';
+      return (
+        <div className={`ds-markdown-paragraph ds-typed-${answerType}`}>
+          <HighReactMarkdown theme={theme} math={math} plugins={plugins}>
+            {content}
+          </HighReactMarkdown>
+        </div>
+      );
+    };
+
     return (
-      <div className={`ds-markdown-paragraph ds-typed-${answerType}`}>
-        <HighReactMarkdown theme={theme} math={math} plugins={plugins}>
-          {wholeContentRef.current[answerType].content || ''}
-        </HighReactMarkdown>
+      <div
+        className={classNames({
+          'ds-markdown': true,
+          apple: true,
+          'ds-markdown-dark': theme === 'dark',
+        })}
+      >
+        <div className="ds-markdown-thinking">{getParagraphs('thinking')}</div>
+
+        <div className="ds-markdown-answer">{getParagraphs('answer')}</div>
       </div>
     );
-  };
-
-  return (
-    <div
-      className={classNames({
-        'ds-markdown': true,
-        apple: true,
-        'ds-markdown-dark': theme === 'dark',
-      })}
-    >
-      <div className="ds-markdown-thinking">{getParagraphs('thinking')}</div>
-
-      <div className="ds-markdown-answer">{getParagraphs('answer')}</div>
-    </div>
-  );
-});
+  },
+);
 
 if (__DEV__) {
   MarkdownCMD.displayName = 'MarkdownCMD';

--- a/src/defined.ts
+++ b/src/defined.ts
@@ -78,6 +78,7 @@ export interface MarkdownProps {
   /** 数学公式配置 */
   math?: IMarkdownMath;
 
+  /** 插件配置 */
   plugins?: IMarkdownPlugin[];
 }
 

--- a/src/hooks/useTypingTask.ts
+++ b/src/hooks/useTypingTask.ts
@@ -10,6 +10,8 @@ interface UseTypingTaskOptions {
   onTypedChar?: (data?: ITypedChar) => void;
   processCharDisplay: (char: IChar) => void;
   wholeContentRef: React.RefObject<IWholeContent>;
+  isClosePrettyTyped: boolean;
+  triggerUpdate: () => void;
 }
 
 export interface TypingTaskController {
@@ -23,7 +25,7 @@ export interface TypingTaskController {
 }
 
 export const useTypingTask = (options: UseTypingTaskOptions): TypingTaskController => {
-  const { timerType = 'setTimeout', interval, charsRef, onEnd, onStart, onTypedChar, processCharDisplay, wholeContentRef } = options;
+  const { timerType = 'setTimeout', interval, charsRef, onEnd, onStart, onTypedChar, processCharDisplay, wholeContentRef, isClosePrettyTyped, triggerUpdate } = options;
   /** 是否卸载 */
   const isUnmountRef = useRef(false);
   /** 是否正在打字 */
@@ -32,12 +34,13 @@ export const useTypingTask = (options: UseTypingTaskOptions): TypingTaskControll
   const animationFrameRef = useRef<number | null>(null);
   /** 传统定时器（兼容模式） */
   const timerRef = useRef<NodeJS.Timeout | null>(null);
-
   // 已经打过的字记录
   const typedCharsRef = useRef<{ typedContent: string; answerType: AnswerType; prevStr: string } | undefined>(undefined);
-
   // 是否主动调用 stop 方法
   const typedIsManualStopRef = useRef(false);
+
+  const isClosePrettyTypedRef = useRef(isClosePrettyTyped);
+  isClosePrettyTypedRef.current = isClosePrettyTyped;
 
   const getChars = () => {
     return charsRef.current;
@@ -172,12 +175,62 @@ export const useTypingTask = (options: UseTypingTaskOptions): TypingTaskControll
     }
   };
 
+  /** 打字机打完所有字符 */
+  function typingRemainAll() {
+    const chars = getChars();
+    const thinkingCharsStr = chars
+      .filter((char) => char.answerType === 'thinking')
+      .map((char) => char.content)
+      .join('');
+    const answerCharsStr = chars
+      .filter((char) => char.answerType === 'answer')
+      .map((char) => char.content)
+      .join('');
+
+    if (thinkingCharsStr) {
+      onTypedChar?.({
+        currentIndex: wholeContentRef.current.thinking.length,
+        currentChar: thinkingCharsStr,
+        answerType: 'thinking',
+        prevStr: typedCharsRef.current?.prevStr || '',
+        percent: 100,
+      });
+    }
+
+    if (answerCharsStr) {
+      onTypedChar?.({
+        currentIndex: wholeContentRef.current.answer.length,
+        currentChar: answerCharsStr,
+        answerType: 'answer',
+        prevStr: typedCharsRef.current?.prevStr || '',
+        percent: 100,
+      });
+    }
+
+    wholeContentRef.current.thinking.content += thinkingCharsStr;
+    wholeContentRef.current.thinking.length += thinkingCharsStr.length;
+    wholeContentRef.current.answer.content += answerCharsStr;
+    wholeContentRef.current.answer.length += answerCharsStr.length;
+    wholeContentRef.current.allLength += thinkingCharsStr.length + answerCharsStr.length;
+    charsRef.current = [];
+    isTypedRef.current = false;
+
+    triggerOnEnd();
+    triggerUpdate();
+  }
+
   /** requestAnimationFrame 模式 */
   const startAnimationFrameMode = () => {
     let lastFrameTime = 0;
 
     const frameLoop = (currentTime: number) => {
+      // 如果关闭打字机效果，则打完所有字符
+      if (isClosePrettyTypedRef.current) {
+        typingRemainAll();
+        return;
+      }
       const chars = getChars();
+
       if (isUnmountRef.current) return;
 
       if (chars.length === 0) {
@@ -247,6 +300,12 @@ export const useTypingTask = (options: UseTypingTaskOptions): TypingTaskControll
     };
 
     const startTyped = (isStartPoint = false) => {
+      // 如果关闭打字机效果，则打完所有字符
+      if (isClosePrettyTypedRef.current) {
+        typingRemainAll();
+        return;
+      }
+
       const chars = getChars();
       if (isUnmountRef.current) return;
 


### PR DESCRIPTION
- 新增 isClosePrettyTyped 参数
    - 在 MarkdownCMDProps 中新增 isClosePrettyTyped 可选参数
    - 当为 true 时，内容会立即显示，不会有打字机效果
- 重构内容推送逻辑
    -  拆分为 processHasTypingPush（打字机模式）和 processNoTypingPush（非打字机模式）
    - 根据 isClosePrettyTyped 参数动态选择推送方式
- 优化打字任务控制
    - 在 useTypingTask hook 中新增 typingRemainAll 方法
    - 支持在运行时动态切换打字机效果开关
    - 当关闭打字机效果时，会立即显示所有剩余内容
